### PR TITLE
Add MKVMerge split, recursive directory add

### DIFF
--- a/BananaSplit/.editorconfig
+++ b/BananaSplit/.editorconfig
@@ -1,0 +1,2 @@
+[*]
+    end_of_line = lf

--- a/BananaSplit/Extensions/Enum.cs
+++ b/BananaSplit/Extensions/Enum.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Text;
 
 namespace BananaSplit.Extensions
 {
@@ -22,7 +20,8 @@ namespace BananaSplit.Extensions
                 {
                     displayNames.Add(field.GetCustomAttribute<DisplayAttribute>().Name);
                 }
-                catch {
+                catch
+                {
                     displayNames.Add(field.Name);
                 }
             }
@@ -42,6 +41,6 @@ namespace BananaSplit.Extensions
             }
         }
 
-        
+
     }
 }

--- a/BananaSplit/FFMPEG.cs
+++ b/BananaSplit/FFMPEG.cs
@@ -9,36 +9,36 @@ namespace BananaSplit
 {
     public class FFMPEG
     {
-        private Process process { get; set; }
+        private Process Process { get; set; }
 
         public FFMPEG()
         {
-            process = new Process();
+            Process = new Process();
 
-            process.StartInfo.UseShellExecute = false;
-            process.StartInfo.RedirectStandardError = true;
-            process.StartInfo.FileName = "ffmpeg.exe";
-            process.StartInfo.CreateNoWindow = true;
+            Process.StartInfo.UseShellExecute = false;
+            Process.StartInfo.RedirectStandardError = true;
+            Process.StartInfo.FileName = "ffmpeg.exe";
+            Process.StartInfo.CreateNoWindow = true;
         }
 
         public bool IsMatroska(string filePath, DataReceivedEventHandler outputHandler)
         {
-            process.StartInfo.FileName = "ffprobe.exe";
-            process.StartInfo.Arguments = $"\"{filePath}\"";
+            Process.StartInfo.FileName = "ffprobe.exe";
+            Process.StartInfo.Arguments = $"\"{filePath}\"";
 
             var output = "";
             DataReceivedEventHandler handler = (s, evt) =>
             {
                 output += evt.Data + "\n"; outputHandler(s, evt);
             };
-            process.ErrorDataReceived += handler;
+            Process.ErrorDataReceived += handler;
 
-            process.Start();
-            process.BeginErrorReadLine();
+            Process.Start();
+            Process.BeginErrorReadLine();
 
-            process.WaitForExit();
-            process.ErrorDataReceived -= handler;
-            process.CancelErrorRead();
+            Process.WaitForExit();
+            Process.ErrorDataReceived -= handler;
+            Process.CancelErrorRead();
 
             string pattern = @"^Input #\d+, matroska";
 
@@ -51,24 +51,24 @@ namespace BananaSplit
         {
             TimeSpan duration = new TimeSpan();
 
-            process.StartInfo.FileName = "ffprobe.exe";
-            process.StartInfo.Arguments = $"\"{filePath}\"";
-            process.StartInfo.RedirectStandardOutput = false;
-            process.StartInfo.RedirectStandardError = true;
+            Process.StartInfo.FileName = "ffprobe.exe";
+            Process.StartInfo.Arguments = $"\"{filePath}\"";
+            Process.StartInfo.RedirectStandardOutput = false;
+            Process.StartInfo.RedirectStandardError = true;
 
             var output = "";
             DataReceivedEventHandler handler = (s, evt) =>
             {
                 output += evt.Data + "\n"; outputHandler(s, evt);
             };
-            process.ErrorDataReceived += handler;
+            Process.ErrorDataReceived += handler;
 
-            process.Start();
-            process.BeginErrorReadLine();
+            Process.Start();
+            Process.BeginErrorReadLine();
 
-            process.WaitForExit();
-            process.ErrorDataReceived -= handler;
-            process.CancelErrorRead();
+            Process.WaitForExit();
+            Process.ErrorDataReceived -= handler;
+            Process.CancelErrorRead();
 
             string pattern = @"^\s+Duration: (?<duration>\d+(?:.\d+)*)";
 
@@ -87,25 +87,25 @@ namespace BananaSplit
         {
             var timespan = String.Format("{0:D2}:{1:D2}:{2:D2}.{3}", time.Hours, time.Minutes, time.Seconds, time.Milliseconds);
 
-            process.StartInfo.FileName = "ffmpeg.exe";
-            process.StartInfo.Arguments = $"-ss {timespan} -i \"{filePath}\" -vframes 1 -c:v png -f image2pipe -";
-            process.StartInfo.RedirectStandardOutput = true;
-            process.StartInfo.RedirectStandardError = true;
+            Process.StartInfo.FileName = "ffmpeg.exe";
+            Process.StartInfo.Arguments = $"-ss {timespan} -i \"{filePath}\" -vframes 1 -c:v png -f image2pipe -";
+            Process.StartInfo.RedirectStandardOutput = true;
+            Process.StartInfo.RedirectStandardError = true;
 
             // ffmpeg uses stderr for some reason
             DataReceivedEventHandler handler = (s, evt) => outputHandler(s, evt);
-            process.ErrorDataReceived += handler;
+            Process.ErrorDataReceived += handler;
 
-            process.Start();
-            process.BeginErrorReadLine();
+            Process.Start();
+            Process.BeginErrorReadLine();
 
             using (MemoryStream ms = new MemoryStream())
             {
-                process.StandardOutput.BaseStream.CopyTo(ms);
+                Process.StandardOutput.BaseStream.CopyTo(ms);
 
-                process.WaitForExit();
-                process.CancelErrorRead();
-                process.ErrorDataReceived -= handler;
+                Process.WaitForExit();
+                Process.CancelErrorRead();
+                Process.ErrorDataReceived -= handler;
 
                 return ms.ToArray();
             }
@@ -120,30 +120,29 @@ namespace BananaSplit
             arguments = arguments.Replace("{end}", String.Format("{0:D2}:{1:D2}:{2:D2}.{3}", segment.End.Hours, segment.End.Minutes, segment.End.Seconds, segment.End.Milliseconds));
             arguments = arguments.Replace("{duration}", String.Format("{0:D2}:{1:D2}:{2:D2}.{3}", segment.Duration.Hours, segment.Duration.Minutes, segment.Duration.Seconds, segment.Duration.Milliseconds));
 
-            process.StartInfo.FileName = "ffmpeg.exe";
-            process.StartInfo.Arguments = arguments;
-            process.StartInfo.RedirectStandardOutput = false;
-            process.StartInfo.RedirectStandardError = true;
+            Process.StartInfo.FileName = "ffmpeg.exe";
+            Process.StartInfo.Arguments = arguments;
+            Process.StartInfo.RedirectStandardOutput = false;
+            Process.StartInfo.RedirectStandardError = true;
 
             // ffmpeg uses stderr for some reason
             DataReceivedEventHandler handler = (s, evt) => outputHandler(s, evt);
-            process.ErrorDataReceived += handler;
-            process.Start();
-            process.BeginErrorReadLine();
+            Process.ErrorDataReceived += handler;
+            Process.Start();
+            Process.BeginErrorReadLine();
 
-            process.WaitForExit();
-            process.ErrorDataReceived -= handler;
-            process.CancelErrorRead();
+            Process.WaitForExit();
+            Process.ErrorDataReceived -= handler;
+            Process.CancelErrorRead();
         }
 
         public ICollection<BlackFrame> DetectBlackFrameIntervals(string filePath, double blackFrameDuration, double blackFrameThreshold, double blackFramePixelThreshold, DataReceivedEventHandler outputHandler)
         {
             var frames = new List<BlackFrame>();
 
-            process.StartInfo.FileName = "ffmpeg.exe";
-            process.StartInfo.RedirectStandardError = true;
-            process.StartInfo.Arguments = $"-i \"{filePath}\" -vf blackdetect=d={blackFrameDuration}:pic_th={blackFrameThreshold}:pix_th={blackFramePixelThreshold} -an -f null -y /NUL";
-            //process.StartInfo.Arguments = $"-i \"{filePath}\" -vf blackframe -f null -y /NUL";
+            Process.StartInfo.FileName = "ffmpeg.exe";
+            Process.StartInfo.RedirectStandardError = true;
+            Process.StartInfo.Arguments = $"-i \"{filePath}\" -vf blackdetect=d={blackFrameDuration}:pic_th={blackFrameThreshold}:pix_th={blackFramePixelThreshold} -an -f null -y /NUL";
 
             // ffmpeg uses stderr for some reason
             var output = "";
@@ -151,14 +150,14 @@ namespace BananaSplit
             {
                 output += evt.Data + "\n"; outputHandler(s, evt);
             };
-            process.ErrorDataReceived += handler;
+            Process.ErrorDataReceived += handler;
 
-            process.Start();
-            process.BeginErrorReadLine();
+            Process.Start();
+            Process.BeginErrorReadLine();
 
-            process.WaitForExit();
-            process.ErrorDataReceived -= handler;
-            process.CancelErrorRead();
+            Process.WaitForExit();
+            Process.ErrorDataReceived -= handler;
+            Process.CancelErrorRead();
 
             string pattern = @"(?:blackdetect.+)(?:black_start:)(?<start>\d+(?:.\d+)*) (?:black_end:)(?<end>\d+(?:.\d+)*) (?:black_duration:)(?<duration>\d+(?:.\d+)*)";
 
@@ -196,9 +195,9 @@ namespace BananaSplit
         {
             var frames = new List<BlackFrame>();
 
-            process.StartInfo.FileName = "ffmpeg.exe";
-            process.StartInfo.RedirectStandardError = true;
-            process.StartInfo.Arguments = $"-i \"{filePath}\" -vf blackframe -f null -y /NUL";
+            Process.StartInfo.FileName = "ffmpeg.exe";
+            Process.StartInfo.RedirectStandardError = true;
+            Process.StartInfo.Arguments = $"-i \"{filePath}\" -vf blackframe -f null -y /NUL";
 
             // ffmpeg uses stderr for some reason
             var output = "";
@@ -206,14 +205,14 @@ namespace BananaSplit
             {
                 output += evt.Data + "\n"; outputHandler(s, evt);
             };
-            process.ErrorDataReceived += handler;
+            Process.ErrorDataReceived += handler;
 
-            process.Start();
-            process.BeginErrorReadLine();
+            Process.Start();
+            Process.BeginErrorReadLine();
 
-            process.WaitForExit();
-            process.ErrorDataReceived -= handler;
-            process.CancelErrorRead();
+            Process.WaitForExit();
+            Process.ErrorDataReceived -= handler;
+            Process.CancelErrorRead();
 
             string pattern = @"t:(?'time'\d+(?:\.\d+)*) type:\w last_keyframe:(?'group'\d+)";
 

--- a/BananaSplit/FFMPEG.cs
+++ b/BananaSplit/FFMPEG.cs
@@ -9,36 +9,36 @@ namespace BananaSplit
 {
     public class FFMPEG
     {
-        private Process Process { get; set; }
+        private Process process { get; set; }
 
         public FFMPEG()
         {
-            Process = new Process();
+            process = new Process();
 
-            Process.StartInfo.UseShellExecute = false;
-            Process.StartInfo.RedirectStandardError = true;
-            Process.StartInfo.FileName = "ffmpeg.exe";
-            Process.StartInfo.CreateNoWindow = true;
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.RedirectStandardError = true;
+            process.StartInfo.FileName = "ffmpeg.exe";
+            process.StartInfo.CreateNoWindow = true;
         }
 
         public bool IsMatroska(string filePath, DataReceivedEventHandler outputHandler)
         {
-            Process.StartInfo.FileName = "ffprobe.exe";
-            Process.StartInfo.Arguments = $"\"{filePath}\"";
+            process.StartInfo.FileName = "ffprobe.exe";
+            process.StartInfo.Arguments = $"\"{filePath}\"";
 
             var output = "";
             DataReceivedEventHandler handler = (s, evt) =>
             {
                 output += evt.Data + "\n"; outputHandler(s, evt);
             };
-            Process.ErrorDataReceived += handler;
+            process.ErrorDataReceived += handler;
 
-            Process.Start();
-            Process.BeginErrorReadLine();
+            process.Start();
+            process.BeginErrorReadLine();
 
-            Process.WaitForExit();
-            Process.ErrorDataReceived -= handler;
-            Process.CancelErrorRead();
+            process.WaitForExit();
+            process.ErrorDataReceived -= handler;
+            process.CancelErrorRead();
 
             string pattern = @"^Input #\d+, matroska";
 
@@ -51,24 +51,24 @@ namespace BananaSplit
         {
             TimeSpan duration = new TimeSpan();
 
-            Process.StartInfo.FileName = "ffprobe.exe";
-            Process.StartInfo.Arguments = $"\"{filePath}\"";
-            Process.StartInfo.RedirectStandardOutput = false;
-            Process.StartInfo.RedirectStandardError = true;
+            process.StartInfo.FileName = "ffprobe.exe";
+            process.StartInfo.Arguments = $"\"{filePath}\"";
+            process.StartInfo.RedirectStandardOutput = false;
+            process.StartInfo.RedirectStandardError = true;
 
             var output = "";
             DataReceivedEventHandler handler = (s, evt) =>
             {
                 output += evt.Data + "\n"; outputHandler(s, evt);
             };
-            Process.ErrorDataReceived += handler;
-            
-            Process.Start();
-            Process.BeginErrorReadLine();
+            process.ErrorDataReceived += handler;
 
-            Process.WaitForExit();
-            Process.ErrorDataReceived -= handler;
-            Process.CancelErrorRead();
+            process.Start();
+            process.BeginErrorReadLine();
+
+            process.WaitForExit();
+            process.ErrorDataReceived -= handler;
+            process.CancelErrorRead();
 
             string pattern = @"^\s+Duration: (?<duration>\d+(?:.\d+)*)";
 
@@ -87,31 +87,31 @@ namespace BananaSplit
         {
             var timespan = String.Format("{0:D2}:{1:D2}:{2:D2}.{3}", time.Hours, time.Minutes, time.Seconds, time.Milliseconds);
 
-            Process.StartInfo.FileName = "ffmpeg.exe";
-            Process.StartInfo.Arguments = $"-ss {timespan} -i \"{filePath}\" -vframes 1 -c:v png -f image2pipe -";
-            Process.StartInfo.RedirectStandardOutput = true;
-            Process.StartInfo.RedirectStandardError = true;
+            process.StartInfo.FileName = "ffmpeg.exe";
+            process.StartInfo.Arguments = $"-ss {timespan} -i \"{filePath}\" -vframes 1 -c:v png -f image2pipe -";
+            process.StartInfo.RedirectStandardOutput = true;
+            process.StartInfo.RedirectStandardError = true;
 
             // ffmpeg uses stderr for some reason
             DataReceivedEventHandler handler = (s, evt) => outputHandler(s, evt);
-            Process.ErrorDataReceived += handler; 
+            process.ErrorDataReceived += handler;
 
-            Process.Start();
-            Process.BeginErrorReadLine();
+            process.Start();
+            process.BeginErrorReadLine();
 
             using (MemoryStream ms = new MemoryStream())
             {
-                Process.StandardOutput.BaseStream.CopyTo(ms);
+                process.StandardOutput.BaseStream.CopyTo(ms);
 
-                Process.WaitForExit();
-                Process.CancelErrorRead();
-                Process.ErrorDataReceived -= handler;
+                process.WaitForExit();
+                process.CancelErrorRead();
+                process.ErrorDataReceived -= handler;
 
                 return ms.ToArray();
             }
         }
 
-       
+
         public void EncodeSegments(string source, string destination, string arguments, Segment segment, DataReceivedEventHandler outputHandler)
         {
             arguments = arguments.Replace("{source}", source);
@@ -120,30 +120,30 @@ namespace BananaSplit
             arguments = arguments.Replace("{end}", String.Format("{0:D2}:{1:D2}:{2:D2}.{3}", segment.End.Hours, segment.End.Minutes, segment.End.Seconds, segment.End.Milliseconds));
             arguments = arguments.Replace("{duration}", String.Format("{0:D2}:{1:D2}:{2:D2}.{3}", segment.Duration.Hours, segment.Duration.Minutes, segment.Duration.Seconds, segment.Duration.Milliseconds));
 
-            Process.StartInfo.FileName = "ffmpeg.exe";
-            Process.StartInfo.Arguments = arguments;
-            Process.StartInfo.RedirectStandardOutput = false;
-            Process.StartInfo.RedirectStandardError = true;
+            process.StartInfo.FileName = "ffmpeg.exe";
+            process.StartInfo.Arguments = arguments;
+            process.StartInfo.RedirectStandardOutput = false;
+            process.StartInfo.RedirectStandardError = true;
 
             // ffmpeg uses stderr for some reason
             DataReceivedEventHandler handler = (s, evt) => outputHandler(s, evt);
-            Process.ErrorDataReceived += handler;
-            Process.Start();
-            Process.BeginErrorReadLine();
+            process.ErrorDataReceived += handler;
+            process.Start();
+            process.BeginErrorReadLine();
 
-            Process.WaitForExit();
-            Process.ErrorDataReceived -= handler;
-            Process.CancelErrorRead();
+            process.WaitForExit();
+            process.ErrorDataReceived -= handler;
+            process.CancelErrorRead();
         }
 
-        public ICollection<BlackFrame> DetectBlackFrameIntervals(string filePath, double blackFrameDuration, double blackFrameThreshold, DataReceivedEventHandler outputHandler)
+        public ICollection<BlackFrame> DetectBlackFrameIntervals(string filePath, double blackFrameDuration, double blackFrameThreshold, double blackFramePixelThreshold, DataReceivedEventHandler outputHandler)
         {
             var frames = new List<BlackFrame>();
 
-            Process.StartInfo.FileName = "ffmpeg.exe";
-            Process.StartInfo.RedirectStandardError = true;
-            Process.StartInfo.Arguments = $"-i \"{filePath}\" -vf blackdetect=d={blackFrameDuration}:pix_th={blackFrameThreshold} -f rawvideo -y /NUL";
-            Process.StartInfo.Arguments = $"-i \"{filePath}\" -vf blackframe -f rawvideo -y /NUL";
+            process.StartInfo.FileName = "ffmpeg.exe";
+            process.StartInfo.RedirectStandardError = true;
+            process.StartInfo.Arguments = $"-i \"{filePath}\" -vf blackdetect=d={blackFrameDuration}:pic_th={blackFrameThreshold}:pix_th={blackFramePixelThreshold} -an -f null -y /NUL";
+            //process.StartInfo.Arguments = $"-i \"{filePath}\" -vf blackframe -f null -y /NUL";
 
             // ffmpeg uses stderr for some reason
             var output = "";
@@ -151,14 +151,14 @@ namespace BananaSplit
             {
                 output += evt.Data + "\n"; outputHandler(s, evt);
             };
-            Process.ErrorDataReceived += handler;
+            process.ErrorDataReceived += handler;
 
-            Process.Start();
-            Process.BeginErrorReadLine();
+            process.Start();
+            process.BeginErrorReadLine();
 
-            Process.WaitForExit();
-            Process.ErrorDataReceived -= handler;
-            Process.CancelErrorRead();
+            process.WaitForExit();
+            process.ErrorDataReceived -= handler;
+            process.CancelErrorRead();
 
             string pattern = @"(?:blackdetect.+)(?:black_start:)(?<start>\d+(?:.\d+)*) (?:black_end:)(?<end>\d+(?:.\d+)*) (?:black_duration:)(?<duration>\d+(?:.\d+)*)";
 
@@ -182,6 +182,7 @@ namespace BananaSplit
                     frame.Start = TimeSpan.FromSeconds((double)start);
                     frame.End = TimeSpan.FromSeconds((double)end);
                     frame.Duration = TimeSpan.FromSeconds((double)duration);
+                    frame.Marker = frame.GetMiddle();
 
                     frames.Add(frame);
                 }
@@ -195,9 +196,9 @@ namespace BananaSplit
         {
             var frames = new List<BlackFrame>();
 
-            Process.StartInfo.FileName = "ffmpeg.exe";
-            Process.StartInfo.RedirectStandardError = true;
-            Process.StartInfo.Arguments = $"-i \"{filePath}\" -vf blackframe -f rawvideo -y /NUL";
+            process.StartInfo.FileName = "ffmpeg.exe";
+            process.StartInfo.RedirectStandardError = true;
+            process.StartInfo.Arguments = $"-i \"{filePath}\" -vf blackframe -f null -y /NUL";
 
             // ffmpeg uses stderr for some reason
             var output = "";
@@ -205,14 +206,14 @@ namespace BananaSplit
             {
                 output += evt.Data + "\n"; outputHandler(s, evt);
             };
-            Process.ErrorDataReceived += handler;
+            process.ErrorDataReceived += handler;
 
-            Process.Start();
-            Process.BeginErrorReadLine();
-            
-            Process.WaitForExit();
-            Process.ErrorDataReceived -= handler;
-            Process.CancelErrorRead();
+            process.Start();
+            process.BeginErrorReadLine();
+
+            process.WaitForExit();
+            process.ErrorDataReceived -= handler;
+            process.CancelErrorRead();
 
             string pattern = @"t:(?'time'\d+(?:\.\d+)*) type:\w last_keyframe:(?'group'\d+)";
 
@@ -222,6 +223,8 @@ namespace BananaSplit
             var blackFrames = new List<TimeSpan>();
 
             var matchGroups = matches.GroupBy(m => m.Groups["group"].Value);
+
+
 
             foreach (var group in matchGroups)
             {

--- a/BananaSplit/LogForm.cs
+++ b/BananaSplit/LogForm.cs
@@ -1,9 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Text;
 using System.Windows.Forms;
 
 namespace BananaSplit

--- a/BananaSplit/MKVToolNix.cs
+++ b/BananaSplit/MKVToolNix.cs
@@ -8,141 +8,194 @@ namespace BananaSplit
 {
     public class MKVToolNix
     {
-        private Process Process { get; set; }
+        private Process process { get; set; }
 
         public MKVToolNix()
         {
-            Process = new Process();
+            process = new Process();
 
-            Process.StartInfo.UseShellExecute = false;
-            Process.StartInfo.RedirectStandardError = true;
-			Process.StartInfo.RedirectStandardOutput = true;
-            Process.StartInfo.CreateNoWindow = true;
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.RedirectStandardError = true;
+            process.StartInfo.RedirectStandardOutput = true;
+            process.StartInfo.CreateNoWindow = true;
         }
 
-		public string RemuxToMatroska(string filepath)
-		{
-			var basename = Path.GetFileNameWithoutExtension(filepath);
-			var path = Path.GetDirectoryName(filepath);
-			var extensionlessPath = Path.Combine(path, basename);
+        public string RemuxToMatroska(string filepath)
+        {
+            var basename = Path.GetFileNameWithoutExtension(filepath);
+            var path = Path.GetDirectoryName(filepath);
+            var extensionlessPath = Path.Combine(path, basename);
 
-			Process.StartInfo.FileName = "mkvmerge.exe";
-			Process.StartInfo.Arguments = $"-o \"{extensionlessPath}.mkv\" \"{filepath}\"";
+            process.StartInfo.FileName = "mkvmerge.exe";
+            process.StartInfo.Arguments = $"-o \"{extensionlessPath}.mkv\" \"{filepath}\"";
 
-			Process.Start();
-			Process.WaitForExit();
+            process.Start();
+            process.WaitForExit();
 
-			return extensionlessPath + ".mkv";
-		}
+            return extensionlessPath + ".mkv";
+        }
 
-		public void InjectChapters(string filepath, Chapters chapters)
-		{
-			var temporaryXmlFile = Path.GetTempFileName();
-			var temporaryOutputFile = Path.GetTempFileName();
+        public void InjectChapters(string filepath, Chapters chapters)
+        {
+            var temporaryXmlFile = Path.GetTempFileName();
+            var temporaryOutputFile = Path.GetTempFileName();
 
-			Process.StartInfo.FileName = "mkvmerge.exe";
-			Process.StartInfo.Arguments = $"--chapters \"{temporaryXmlFile}\" -o \"{temporaryOutputFile}\" \"{filepath}\"";
+            process.StartInfo.FileName = "mkvmerge.exe";
+            process.StartInfo.Arguments = $"--chapters \"{temporaryXmlFile}\" -o \"{temporaryOutputFile}\" \"{filepath}\"";
 
-			XmlSerializer serializer = new XmlSerializer(typeof(Chapters));
-			XmlSerializerNamespaces namespaces = new XmlSerializerNamespaces();
-			namespaces.Add("", "");
+            XmlSerializer serializer = new XmlSerializer(typeof(Chapters));
+            XmlSerializerNamespaces namespaces = new XmlSerializerNamespaces();
+            namespaces.Add("", "");
 
-			TextWriter writer = new StreamWriter(temporaryXmlFile);
+            TextWriter writer = new StreamWriter(temporaryXmlFile);
 
-			serializer.Serialize(writer, chapters, namespaces);
+            serializer.Serialize(writer, chapters, namespaces);
 
-			writer.Close();
+            writer.Close();
 
-			Process.Start();
+            process.Start();
 
-			var error = Process.StandardError.ReadToEnd();
-			var output = Process.StandardOutput.ReadToEnd();
+            var error = process.StandardError.ReadToEnd();
+            var output = process.StandardOutput.ReadToEnd();
 
-			Process.WaitForExit();
+            process.WaitForExit();
 
-			File.Delete(filepath);
-			File.Move(temporaryOutputFile, filepath);
-			File.Delete(temporaryXmlFile);
-		}
+            File.Delete(filepath);
+            File.Move(temporaryOutputFile, filepath);
+            File.Delete(temporaryXmlFile);
+        }
 
-		public Chapters GenerateChapters(IEnumerable<TimeSpan> segments)
-		{
-			var chapters = new Chapters();
-			var editionEntry = new EditionEntry() {
-				EditionFlagHidden = 0,
-				EditionFlagDefault = 0,
-				EditionUID = 1,
-				ChapterAtom = new List<ChapterAtom>()
-			};
+        public Chapters GenerateChapters(IEnumerable<TimeSpan> segments)
+        {
+            var chapters = new Chapters();
+            var editionEntry = new EditionEntry()
+            {
+                EditionFlagHidden = 0,
+                EditionFlagDefault = 0,
+                EditionUID = 1,
+                ChapterAtom = new List<ChapterAtom>()
+            };
 
-			int i = 1;
+            int i = 1;
 
-			foreach (var segment in segments)
-			{
-				var chapterAtom = new ChapterAtom();
-				var timestamp = String.Format("{0:D2}:{1:D2}:{2:D2}.{3}", segment.Hours, segment.Minutes, segment.Seconds, segment.Milliseconds);
+            foreach (var segment in segments)
+            {
+                var chapterAtom = new ChapterAtom();
+                var timestamp = String.Format("{0:D2}:{1:D2}:{2:D2}.{3}", segment.Hours, segment.Minutes, segment.Seconds, segment.Milliseconds);
 
-				chapterAtom.ChapterUID = i;
-				chapterAtom.ChapterFlagHidden = 0;
-				chapterAtom.ChapterFlagEnabled = 1;
-				chapterAtom.ChapterTimeStart = timestamp;
-				chapterAtom.ChapterDisplay = new ChapterDisplay()
-				{
-					ChapterLanguage = "eng",
-					ChapterString = timestamp
-				};
+                chapterAtom.ChapterUID = i;
+                chapterAtom.ChapterFlagHidden = 0;
+                chapterAtom.ChapterFlagEnabled = 1;
+                chapterAtom.ChapterTimeStart = timestamp;
+                chapterAtom.ChapterDisplay = new ChapterDisplay()
+                {
+                    ChapterLanguage = "eng",
+                    ChapterString = timestamp
+                };
 
-				editionEntry.ChapterAtom.Add(chapterAtom);
+                editionEntry.ChapterAtom.Add(chapterAtom);
 
-				i++;
-			}
+                i++;
+            }
 
-			chapters.EditionEntry = editionEntry;
-			return chapters;
-		}
+            chapters.EditionEntry = editionEntry;
+            return chapters;
+        }
+
+
+        public void SplitSegments(string source, string destination, string arguments, List<Segment> segments, DataReceivedEventHandler outputHandler)
+        {
+            if (segments.Count <= 1)
+            {
+                File.Copy(source, destination.Replace("%03d", "1"), true);
+                return;
+            }
+
+            // make sure the segments are in order
+            segments.Sort((a, b) => a.End.CompareTo(b.End));
+
+            segments.RemoveAt(segments.Count - 1); // last segment's end would be the end of the file
+
+            string cuts = "";
+
+            bool first = true;
+
+            foreach (var segment in segments)
+            {
+                if (!first)
+                {
+                    cuts += ",";
+                }
+                first = false;
+
+                cuts += String.Format("{0:D2}:{1:D2}:{2:D2}.{3}", segment.End.Hours, segment.End.Minutes, segment.End.Seconds, segment.End.Milliseconds);
+
+            }
+
+            process.StartInfo.FileName = "mkvmerge.exe";
+            process.StartInfo.Arguments = $"-o \"{destination}\" --split timecodes:{cuts} \"{source}\"";
+            process.StartInfo.RedirectStandardOutput = false;
+            process.StartInfo.RedirectStandardError = true;
+
+
+            DataReceivedEventHandler handler = (s, evt) => outputHandler(s, evt);
+            process.ErrorDataReceived += handler;
+            process.Start();
+
+            //var error = process.StandardError.ReadToEnd();
+            //var output = process.StandardOutput.ReadToEnd();
+
+            process.WaitForExit();
+        }
+
+
+
+
     }
 
-	[XmlRoot(ElementName = "ChapterDisplay")]
-	public class ChapterDisplay
-	{
-		[XmlElement(ElementName = "ChapterString")]
-		public string ChapterString { get; set; }
-		[XmlElement(ElementName = "ChapterLanguage")]
-		public string ChapterLanguage { get; set; }
-	}
 
-	[XmlRoot(ElementName = "ChapterAtom")]
-	public class ChapterAtom
-	{
-		[XmlElement(ElementName = "ChapterUID")]
-		public int ChapterUID { get; set; }
-		[XmlElement(ElementName = "ChapterTimeStart")]
-		public string ChapterTimeStart { get; set; }
-		[XmlElement(ElementName = "ChapterFlagHidden")]
-		public int ChapterFlagHidden { get; set; }
-		[XmlElement(ElementName = "ChapterFlagEnabled")]
-		public int ChapterFlagEnabled { get; set; }
-		[XmlElement(ElementName = "ChapterDisplay")]
-		public ChapterDisplay ChapterDisplay { get; set; }
-	}
 
-	[XmlRoot(ElementName = "EditionEntry")]
-	public class EditionEntry
-	{
-		[XmlElement(ElementName = "EditionFlagHidden")]
-		public int EditionFlagHidden { get; set; }
-		[XmlElement(ElementName = "EditionFlagDefault")]
-		public int EditionFlagDefault { get; set; }
-		[XmlElement(ElementName = "EditionUID")]
-		public int EditionUID { get; set; }
-		[XmlElement(ElementName = "ChapterAtom")]
-		public List<ChapterAtom> ChapterAtom { get; set; }
-	}
+    [XmlRoot(ElementName = "ChapterDisplay")]
+    public class ChapterDisplay
+    {
+        [XmlElement(ElementName = "ChapterString")]
+        public string ChapterString { get; set; }
+        [XmlElement(ElementName = "ChapterLanguage")]
+        public string ChapterLanguage { get; set; }
+    }
 
-	[XmlRoot(ElementName = "Chapters")]
-	public class Chapters
-	{
-		[XmlElement(ElementName = "EditionEntry")]
-		public EditionEntry EditionEntry { get; set; }
-	}
+    [XmlRoot(ElementName = "ChapterAtom")]
+    public class ChapterAtom
+    {
+        [XmlElement(ElementName = "ChapterUID")]
+        public int ChapterUID { get; set; }
+        [XmlElement(ElementName = "ChapterTimeStart")]
+        public string ChapterTimeStart { get; set; }
+        [XmlElement(ElementName = "ChapterFlagHidden")]
+        public int ChapterFlagHidden { get; set; }
+        [XmlElement(ElementName = "ChapterFlagEnabled")]
+        public int ChapterFlagEnabled { get; set; }
+        [XmlElement(ElementName = "ChapterDisplay")]
+        public ChapterDisplay ChapterDisplay { get; set; }
+    }
+
+    [XmlRoot(ElementName = "EditionEntry")]
+    public class EditionEntry
+    {
+        [XmlElement(ElementName = "EditionFlagHidden")]
+        public int EditionFlagHidden { get; set; }
+        [XmlElement(ElementName = "EditionFlagDefault")]
+        public int EditionFlagDefault { get; set; }
+        [XmlElement(ElementName = "EditionUID")]
+        public int EditionUID { get; set; }
+        [XmlElement(ElementName = "ChapterAtom")]
+        public List<ChapterAtom> ChapterAtom { get; set; }
+    }
+
+    [XmlRoot(ElementName = "Chapters")]
+    public class Chapters
+    {
+        [XmlElement(ElementName = "EditionEntry")]
+        public EditionEntry EditionEntry { get; set; }
+    }
 }

--- a/BananaSplit/Program.cs
+++ b/BananaSplit/Program.cs
@@ -3,13 +3,13 @@ using System.Windows.Forms;
 
 namespace BananaSplit
 {
-    static class Program
+    internal static class Program
     {
         /// <summary>
         /// The main entry point for the application.
         /// </summary>
         [STAThread]
-        static void Main()
+        private static void Main()
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);

--- a/BananaSplit/Segment.cs
+++ b/BananaSplit/Segment.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace BananaSplit
 {
@@ -8,8 +6,10 @@ namespace BananaSplit
     {
         public TimeSpan Start { get; set; }
         public TimeSpan End { get; set; }
-        public TimeSpan Duration {
-            get {
+        public TimeSpan Duration
+        {
+            get
+            {
                 return End.Subtract(Start);
             }
         }

--- a/BananaSplit/Settings.cs
+++ b/BananaSplit/Settings.cs
@@ -1,11 +1,6 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
-using System.Configuration;
 using System.IO;
-using System.Text;
 
 namespace BananaSplit
 {
@@ -14,13 +9,16 @@ namespace BananaSplit
         [Display(Name = "Matroska Chapters")]
         MatroskaChapters,
         [Display(Name = "Split and Encode")]
-        SplitAndEncode
+        SplitAndEncode,
+        [Display(Name = "MKVToolNix Split")]
+        MKVToolNixSplit
     }
 
     public class Settings
     {
         public double BlackFrameDuration { get; set; }
         public double BlackFrameThreshold { get; set; }
+        public double BlackFramePixelThreshold { get; set; }
         public string FFMPEGArguments { get; set; }
         public ProcessingType ProcessType { get; set; }
         public bool ShowLog { get; set; }
@@ -30,9 +28,10 @@ namespace BananaSplit
         public Settings()
         {
             BlackFrameDuration = 0.04;
-            BlackFrameThreshold = 0.01;
+            BlackFrameThreshold = 0.98;
+            BlackFramePixelThreshold = 0.15;
             FFMPEGArguments = "-i \"{source}\" -ss {start} -t {duration} -c:v libx264 -crf 18 -preset slow -c:a copy -map 0 \"{destination}\"";
-            ProcessType = ProcessingType.SplitAndEncode;
+            ProcessType = ProcessingType.MKVToolNixSplit;
             ShowLog = false;
             DeleteOriginal = false;
             ReferenceFrameOffset = 1;
@@ -64,6 +63,7 @@ namespace BananaSplit
 
             BlackFrameDuration = settings.BlackFrameDuration;
             BlackFrameThreshold = settings.BlackFrameThreshold;
+            BlackFramePixelThreshold = settings.BlackFramePixelThreshold;
             FFMPEGArguments = settings.FFMPEGArguments;
             ProcessType = settings.ProcessType;
             ShowLog = settings.ShowLog;

--- a/BananaSplit/SettingsForm.Designer.cs
+++ b/BananaSplit/SettingsForm.Designer.cs
@@ -30,9 +30,9 @@
         {
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tabPage1 = new System.Windows.Forms.TabPage();
+            this.BlackFramePixelThresholdInput = new System.Windows.Forms.NumericUpDown();
+            this.label1 = new System.Windows.Forms.Label();
             this.ShowLogCheckbox = new System.Windows.Forms.CheckBox();
-            this.FFMPEGArgumentsLegend = new System.Windows.Forms.Label();
-            this.FFMPEGArgumentsInput = new System.Windows.Forms.TextBox();
             this.ReferenceFrameOffsetLabel = new System.Windows.Forms.Label();
             this.ReferenceFrameOffsetInput = new System.Windows.Forms.NumericUpDown();
             this.DeleteOriginalCheckbox = new System.Windows.Forms.CheckBox();
@@ -43,29 +43,36 @@
             this.BlackFrameThresholdLabel = new System.Windows.Forms.Label();
             this.BlackFrameDurationLabel = new System.Windows.Forms.Label();
             this.FFMPEGArgumentsGroupBox = new System.Windows.Forms.GroupBox();
+            this.FFMPEGArgumentsInput = new System.Windows.Forms.TextBox();
+            this.FFMPEGArgumentsLegend = new System.Windows.Forms.Label();
             this.SaveButton = new System.Windows.Forms.Button();
             this.tabControl1.SuspendLayout();
             this.tabPage1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.BlackFramePixelThresholdInput)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.ReferenceFrameOffsetInput)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.BlackFrameDurationInput)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.BlackFrameThresholdInput)).BeginInit();
+            this.FFMPEGArgumentsGroupBox.SuspendLayout();
             this.SuspendLayout();
             // 
             // tabControl1
             // 
+            this.tabControl1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.tabControl1.Controls.Add(this.tabPage1);
-            this.tabControl1.Location = new System.Drawing.Point(26, 30);
+            this.tabControl1.Location = new System.Drawing.Point(16, 15);
             this.tabControl1.Margin = new System.Windows.Forms.Padding(7, 6, 7, 6);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(911, 999);
+            this.tabControl1.Size = new System.Drawing.Size(912, 862);
             this.tabControl1.TabIndex = 0;
             // 
             // tabPage1
             // 
+            this.tabPage1.Controls.Add(this.BlackFramePixelThresholdInput);
+            this.tabPage1.Controls.Add(this.label1);
             this.tabPage1.Controls.Add(this.ShowLogCheckbox);
-            this.tabPage1.Controls.Add(this.FFMPEGArgumentsLegend);
-            this.tabPage1.Controls.Add(this.FFMPEGArgumentsInput);
             this.tabPage1.Controls.Add(this.ReferenceFrameOffsetLabel);
             this.tabPage1.Controls.Add(this.ReferenceFrameOffsetInput);
             this.tabPage1.Controls.Add(this.DeleteOriginalCheckbox);
@@ -80,44 +87,46 @@
             this.tabPage1.Margin = new System.Windows.Forms.Padding(7, 6, 7, 6);
             this.tabPage1.Name = "tabPage1";
             this.tabPage1.Padding = new System.Windows.Forms.Padding(7, 6, 7, 6);
-            this.tabPage1.Size = new System.Drawing.Size(895, 945);
+            this.tabPage1.Size = new System.Drawing.Size(896, 808);
             this.tabPage1.TabIndex = 0;
             this.tabPage1.Text = "General";
             this.tabPage1.UseVisualStyleBackColor = true;
             // 
+            // BlackFramePixelThresholdInput
+            // 
+            this.BlackFramePixelThresholdInput.DecimalPlaces = 1;
+            this.BlackFramePixelThresholdInput.Location = new System.Drawing.Point(13, 117);
+            this.BlackFramePixelThresholdInput.Margin = new System.Windows.Forms.Padding(6);
+            this.BlackFramePixelThresholdInput.Name = "BlackFramePixelThresholdInput";
+            this.BlackFramePixelThresholdInput.Size = new System.Drawing.Size(260, 39);
+            this.BlackFramePixelThresholdInput.TabIndex = 12;
+            this.BlackFramePixelThresholdInput.Tag = "BlackFramePixelThreshold";
+            this.BlackFramePixelThresholdInput.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(290, 119);
+            this.label1.Margin = new System.Windows.Forms.Padding(7, 0, 7, 0);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(238, 32);
+            this.label1.TabIndex = 11;
+            this.label1.Text = "Black Pixel Threshold";
+            // 
             // ShowLogCheckbox
             // 
             this.ShowLogCheckbox.AutoSize = true;
-            this.ShowLogCheckbox.Location = new System.Drawing.Point(13, 265);
+            this.ShowLogCheckbox.Location = new System.Drawing.Point(13, 268);
             this.ShowLogCheckbox.Name = "ShowLogCheckbox";
             this.ShowLogCheckbox.Size = new System.Drawing.Size(150, 36);
             this.ShowLogCheckbox.TabIndex = 7;
             this.ShowLogCheckbox.Text = "Show Log";
             this.ShowLogCheckbox.UseVisualStyleBackColor = true;
             // 
-            // FFMPEGArgumentsLegend
-            // 
-            this.FFMPEGArgumentsLegend.AutoSize = true;
-            this.FFMPEGArgumentsLegend.Location = new System.Drawing.Point(708, 434);
-            this.FFMPEGArgumentsLegend.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
-            this.FFMPEGArgumentsLegend.Name = "FFMPEGArgumentsLegend";
-            this.FFMPEGArgumentsLegend.Size = new System.Drawing.Size(147, 192);
-            this.FFMPEGArgumentsLegend.TabIndex = 11;
-            this.FFMPEGArgumentsLegend.Text = "Legend:\r\n{source}\r\n{destination}\r\n{start}\r\n{end}\r\n{duration}";
-            // 
-            // FFMPEGArgumentsInput
-            // 
-            this.FFMPEGArgumentsInput.Location = new System.Drawing.Point(30, 427);
-            this.FFMPEGArgumentsInput.Margin = new System.Windows.Forms.Padding(6);
-            this.FFMPEGArgumentsInput.Multiline = true;
-            this.FFMPEGArgumentsInput.Name = "FFMPEGArgumentsInput";
-            this.FFMPEGArgumentsInput.Size = new System.Drawing.Size(663, 458);
-            this.FFMPEGArgumentsInput.TabIndex = 9;
-            // 
             // ReferenceFrameOffsetLabel
             // 
             this.ReferenceFrameOffsetLabel.AutoSize = true;
-            this.ReferenceFrameOffsetLabel.Location = new System.Drawing.Point(290, 147);
+            this.ReferenceFrameOffsetLabel.Location = new System.Drawing.Point(290, 170);
             this.ReferenceFrameOffsetLabel.Margin = new System.Windows.Forms.Padding(7, 0, 7, 0);
             this.ReferenceFrameOffsetLabel.Name = "ReferenceFrameOffsetLabel";
             this.ReferenceFrameOffsetLabel.Size = new System.Drawing.Size(296, 32);
@@ -127,7 +136,7 @@
             // ReferenceFrameOffsetInput
             // 
             this.ReferenceFrameOffsetInput.DecimalPlaces = 1;
-            this.ReferenceFrameOffsetInput.Location = new System.Drawing.Point(13, 141);
+            this.ReferenceFrameOffsetInput.Location = new System.Drawing.Point(13, 168);
             this.ReferenceFrameOffsetInput.Margin = new System.Windows.Forms.Padding(6);
             this.ReferenceFrameOffsetInput.Name = "ReferenceFrameOffsetInput";
             this.ReferenceFrameOffsetInput.Size = new System.Drawing.Size(260, 39);
@@ -138,7 +147,7 @@
             // DeleteOriginalCheckbox
             // 
             this.DeleteOriginalCheckbox.AutoSize = true;
-            this.DeleteOriginalCheckbox.Location = new System.Drawing.Point(13, 323);
+            this.DeleteOriginalCheckbox.Location = new System.Drawing.Point(13, 313);
             this.DeleteOriginalCheckbox.Margin = new System.Windows.Forms.Padding(6);
             this.DeleteOriginalCheckbox.Name = "DeleteOriginalCheckbox";
             this.DeleteOriginalCheckbox.Size = new System.Drawing.Size(308, 36);
@@ -149,7 +158,7 @@
             // ProcessTypeLabel
             // 
             this.ProcessTypeLabel.AutoSize = true;
-            this.ProcessTypeLabel.Location = new System.Drawing.Point(290, 207);
+            this.ProcessTypeLabel.Location = new System.Drawing.Point(290, 222);
             this.ProcessTypeLabel.Margin = new System.Windows.Forms.Padding(7, 0, 7, 0);
             this.ProcessTypeLabel.Name = "ProcessTypeLabel";
             this.ProcessTypeLabel.Size = new System.Drawing.Size(219, 32);
@@ -159,10 +168,10 @@
             // ProcessTypeComboBox
             // 
             this.ProcessTypeComboBox.FormattingEnabled = true;
-            this.ProcessTypeComboBox.Location = new System.Drawing.Point(13, 203);
+            this.ProcessTypeComboBox.Location = new System.Drawing.Point(13, 219);
             this.ProcessTypeComboBox.Margin = new System.Windows.Forms.Padding(6);
             this.ProcessTypeComboBox.Name = "ProcessTypeComboBox";
-            this.ProcessTypeComboBox.Size = new System.Drawing.Size(257, 40);
+            this.ProcessTypeComboBox.Size = new System.Drawing.Size(260, 40);
             this.ProcessTypeComboBox.TabIndex = 6;
             this.ProcessTypeComboBox.Tag = "Settings.ProcessType";
             // 
@@ -180,7 +189,7 @@
             // BlackFrameThresholdInput
             // 
             this.BlackFrameThresholdInput.DecimalPlaces = 1;
-            this.BlackFrameThresholdInput.Location = new System.Drawing.Point(13, 79);
+            this.BlackFrameThresholdInput.Location = new System.Drawing.Point(13, 66);
             this.BlackFrameThresholdInput.Margin = new System.Windows.Forms.Padding(6);
             this.BlackFrameThresholdInput.Name = "BlackFrameThresholdInput";
             this.BlackFrameThresholdInput.Size = new System.Drawing.Size(260, 39);
@@ -191,7 +200,7 @@
             // BlackFrameThresholdLabel
             // 
             this.BlackFrameThresholdLabel.AutoSize = true;
-            this.BlackFrameThresholdLabel.Location = new System.Drawing.Point(290, 85);
+            this.BlackFrameThresholdLabel.Location = new System.Drawing.Point(290, 68);
             this.BlackFrameThresholdLabel.Margin = new System.Windows.Forms.Padding(7, 0, 7, 0);
             this.BlackFrameThresholdLabel.Name = "BlackFrameThresholdLabel";
             this.BlackFrameThresholdLabel.Size = new System.Drawing.Size(255, 32);
@@ -201,7 +210,7 @@
             // BlackFrameDurationLabel
             // 
             this.BlackFrameDurationLabel.AutoSize = true;
-            this.BlackFrameDurationLabel.Location = new System.Drawing.Point(290, 26);
+            this.BlackFrameDurationLabel.Location = new System.Drawing.Point(290, 17);
             this.BlackFrameDurationLabel.Margin = new System.Windows.Forms.Padding(7, 0, 7, 0);
             this.BlackFrameDurationLabel.Name = "BlackFrameDurationLabel";
             this.BlackFrameDurationLabel.Size = new System.Drawing.Size(273, 32);
@@ -210,18 +219,47 @@
             // 
             // FFMPEGArgumentsGroupBox
             // 
-            this.FFMPEGArgumentsGroupBox.Location = new System.Drawing.Point(13, 387);
+            this.FFMPEGArgumentsGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.FFMPEGArgumentsGroupBox.Controls.Add(this.FFMPEGArgumentsInput);
+            this.FFMPEGArgumentsGroupBox.Controls.Add(this.FFMPEGArgumentsLegend);
+            this.FFMPEGArgumentsGroupBox.Location = new System.Drawing.Point(13, 361);
             this.FFMPEGArgumentsGroupBox.Margin = new System.Windows.Forms.Padding(6);
             this.FFMPEGArgumentsGroupBox.Name = "FFMPEGArgumentsGroupBox";
             this.FFMPEGArgumentsGroupBox.Padding = new System.Windows.Forms.Padding(6);
-            this.FFMPEGArgumentsGroupBox.Size = new System.Drawing.Size(861, 525);
+            this.FFMPEGArgumentsGroupBox.Size = new System.Drawing.Size(862, 435);
             this.FFMPEGArgumentsGroupBox.TabIndex = 10;
             this.FFMPEGArgumentsGroupBox.TabStop = false;
             this.FFMPEGArgumentsGroupBox.Text = "FFMPEG Arguments";
             // 
+            // FFMPEGArgumentsInput
+            // 
+            this.FFMPEGArgumentsInput.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.FFMPEGArgumentsInput.Location = new System.Drawing.Point(12, 44);
+            this.FFMPEGArgumentsInput.Margin = new System.Windows.Forms.Padding(6);
+            this.FFMPEGArgumentsInput.Multiline = true;
+            this.FFMPEGArgumentsInput.Name = "FFMPEGArgumentsInput";
+            this.FFMPEGArgumentsInput.Size = new System.Drawing.Size(664, 379);
+            this.FFMPEGArgumentsInput.TabIndex = 9;
+            // 
+            // FFMPEGArgumentsLegend
+            // 
+            this.FFMPEGArgumentsLegend.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.FFMPEGArgumentsLegend.AutoSize = true;
+            this.FFMPEGArgumentsLegend.Location = new System.Drawing.Point(688, 47);
+            this.FFMPEGArgumentsLegend.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.FFMPEGArgumentsLegend.Name = "FFMPEGArgumentsLegend";
+            this.FFMPEGArgumentsLegend.Size = new System.Drawing.Size(147, 192);
+            this.FFMPEGArgumentsLegend.TabIndex = 11;
+            this.FFMPEGArgumentsLegend.Text = "Legend:\r\n{source}\r\n{destination}\r\n{start}\r\n{end}\r\n{duration}";
+            // 
             // SaveButton
             // 
-            this.SaveButton.Location = new System.Drawing.Point(790, 1054);
+            this.SaveButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.SaveButton.Location = new System.Drawing.Point(790, 889);
             this.SaveButton.Margin = new System.Windows.Forms.Padding(6);
             this.SaveButton.Name = "SaveButton";
             this.SaveButton.Size = new System.Drawing.Size(139, 49);
@@ -231,26 +269,27 @@
             // 
             // SettingsForm
             // 
+            this.AcceptButton = this.SaveButton;
             this.AutoScaleDimensions = new System.Drawing.SizeF(192F, 192F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.AutoSize = true;
-            this.ClientSize = new System.Drawing.Size(953, 1127);
+            this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.ClientSize = new System.Drawing.Size(944, 953);
             this.Controls.Add(this.SaveButton);
             this.Controls.Add(this.tabControl1);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.Margin = new System.Windows.Forms.Padding(7, 6, 7, 6);
-            this.MaximizeBox = false;
-            this.MinimizeBox = false;
             this.Name = "SettingsForm";
             this.ShowIcon = false;
+            this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Show;
             this.Text = "Settings";
-            this.TopMost = true;
             this.tabControl1.ResumeLayout(false);
             this.tabPage1.ResumeLayout(false);
             this.tabPage1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.BlackFramePixelThresholdInput)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.ReferenceFrameOffsetInput)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.BlackFrameDurationInput)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.BlackFrameThresholdInput)).EndInit();
+            this.FFMPEGArgumentsGroupBox.ResumeLayout(false);
+            this.FFMPEGArgumentsGroupBox.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -273,5 +312,7 @@
         private System.Windows.Forms.GroupBox FFMPEGArgumentsGroupBox;
         private System.Windows.Forms.Button SaveButton;
         private System.Windows.Forms.CheckBox ShowLogCheckbox;
+        private System.Windows.Forms.NumericUpDown BlackFramePixelThresholdInput;
+        private System.Windows.Forms.Label label1;
     }
 }

--- a/BananaSplit/SettingsForm.cs
+++ b/BananaSplit/SettingsForm.cs
@@ -1,6 +1,5 @@
 ﻿using BananaSplit.Extensions;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
 
@@ -19,10 +18,12 @@ namespace BananaSplit
 
             BlackFrameDurationInput.Increment = (decimal)0.01;
             BlackFrameThresholdInput.Increment = (decimal)0.01;
+            BlackFramePixelThresholdInput.Increment = (decimal)0.01;
             ReferenceFrameOffsetInput.Increment = (decimal)0.1;
 
             BlackFrameDurationInput.DecimalPlaces = 2;
             BlackFrameThresholdInput.DecimalPlaces = 2;
+            BlackFramePixelThresholdInput.DecimalPlaces = 2;
             ReferenceFrameOffsetInput.DecimalPlaces = 1;
 
             ProcessTypeComboBox.Items.Clear();
@@ -33,6 +34,7 @@ namespace BananaSplit
 
             BlackFrameDurationInput.Value = (decimal)Settings.BlackFrameDuration;
             BlackFrameThresholdInput.Value = (decimal)Settings.BlackFrameThreshold;
+            BlackFramePixelThresholdInput.Value = (decimal)Settings.BlackFramePixelThreshold;
             ReferenceFrameOffsetInput.Value = (decimal)Settings.ReferenceFrameOffset;
             ShowLogCheckbox.Checked = Settings.ShowLog;
             DeleteOriginalCheckbox.Checked = Settings.DeleteOriginal;
@@ -44,11 +46,12 @@ namespace BananaSplit
         {
             Settings.BlackFrameDuration = (double)BlackFrameDurationInput.Value;
             Settings.BlackFrameThreshold = (double)BlackFrameThresholdInput.Value;
+            Settings.BlackFramePixelThreshold = (double)BlackFramePixelThresholdInput.Value;
             Settings.ReferenceFrameOffset = (double)ReferenceFrameOffsetInput.Value;
             Settings.ShowLog = ShowLogCheckbox.Checked;
             Settings.DeleteOriginal = DeleteOriginalCheckbox.Checked;
             Settings.FFMPEGArguments = FFMPEGArgumentsInput.Text;
-            
+
             foreach (ProcessingType type in (ProcessingType[])Enum.GetValues(typeof(ProcessingType)))
             {
                 if (type.GetDisplayName() == (string)ProcessTypeComboBox.SelectedItem)


### PR DESCRIPTION
Option to use MKVMerge to split the files to avoid re-encoding.
Now recursively scans sub-directories when adding.
Adds support for drag/dropping directories.
Fixed blackframe options being ignored.
Added option for pixel threshold.
Fixed: Split should happen mid way through black transition.
Options screen elements anchored properly to allow resizing.